### PR TITLE
Adding an Ansible playbook with HaschiCorp Vault Authentication to DockerHub

### DIFF
--- a/ansible/playbook_vault_auth.yml
+++ b/ansible/playbook_vault_auth.yml
@@ -1,0 +1,65 @@
+- hosts: localhost
+  gather_facts: no
+  become: no
+
+  vars:
+    code_directory: "~/DevOps/git/ansible/code_2"
+    image_name: "georgiyovchev/devops-programme-ans"
+    image_tag: "beta"
+    listen_port: "5000"
+    mapped_port: "5000"
+    repo_name: "georgiyovchev/devops-practice"
+    branch_name: "main"
+    docker_repo: "georgiyovchev/my-python-app"
+    username: "{{lookup('hashi_vault', 'secrets/data/dev:username') }}"
+    password: "{{lookup('hashi_vault', 'secrets/data/dev:password') }}"
+
+  tasks:
+    - name: Create code directory
+      file:
+        dest: "{{ code_directory }}"
+        state: directory
+
+    - name: Get the code from GitHub
+      git:
+        repo: git@github.com:{{ repo_name }}
+        version: "{{ branch_name }}"
+        dest: "{{ code_directory }}"
+
+    - name: Build an image from Dockerfile
+      community.docker.docker_image:
+        name: "{{ image_name }}:{{ image_tag }}"
+        source: build
+        build:
+          path: "{{ code_directory }}"
+          args:
+            listen_port: "{{ listen_port }}"
+
+    - name: Login to the Vault
+      community.hashi_vault.vault_login:
+        url: http://localhost:8200
+        auth_method: token
+        token: "{{ lookup('env', 'VAULT_TOKEN') }}"
+      register: login_data
+
+    - name: Log into Docker Hub
+      community.docker.docker_login:
+        username: "{{ username }}"
+        password: "{{ password }}"
+
+    - name: Push the image to Dockerhub repo
+      community.docker.docker_image:
+        name: "{{ image_name }}:{{ image_tag }}"
+        push: true
+        repository: "{{ docker_repo }}"
+        source: local
+
+    - name: Run the Docker container and map port 5000
+      docker_container:
+        name: my_python_app
+        image: "{{ image_name }}:{{ image_tag }}"
+        ports:
+          - "{{ mapped_port }}:{{ listen_port }}"
+        env:
+          PORT: "{{ listen_port }}"
+


### PR DESCRIPTION
In my previous homework assignment, I committed an Ansible playbook with Ansible Vault authentication. 

Therefore, this time I have committed another playbook (playbook_vault_auth.yml) that includes HashiCorp Vault authentication which is also working fine.
- I have defined variables that read the username and password from the Vault.
- I have added an ansible module that is logging into the Vault using the VAULT_TOKEN environment variable. 
- I have set the VAULT_TOKEN environment variable with the token provided in the demo.

![ansible_playbook_vaulth_auth](https://github.com/GeorgiYovchev/devops-practice/assets/139002375/adce376d-37c1-4011-96c1-5c670bd8da6d)
